### PR TITLE
Use manaual sql-transaction to prevent deadlocks

### DIFF
--- a/lib/Doctrine/AuditLog.php
+++ b/lib/Doctrine/AuditLog.php
@@ -150,8 +150,11 @@ class Doctrine_AuditLog extends Doctrine_Record_Generator
      */
     public function getMaxVersion(Doctrine_Record $record)
     {
-        $className = $this->_options['className'];
-        $select = 'MAX(' . $className . '.' . $this->_options['version']['name'] . ') max_version';
+        if ($record->isNew()) {
+            return 0;
+        }
+        $className = get_class($record);
+        $select = $className . '.' . $this->_options['version']['name'] . ' max_version';
 
         foreach ((array) $this->_options['table']->getIdentifier() as $id) {
             $conditions[] = $className . '.' . $id . ' = ?';
@@ -165,22 +168,8 @@ class Doctrine_AuditLog extends Doctrine_Record_Generator
             ->forUpdate()
             ->where(implode(' AND ',$conditions));
 
-        // Try to execute the FOR UPDATE query
-        // this can result in a deadlock, in which case we should try again
-        $querySucceeded = false;
-        $num = 0;
-        do {
-            try {
-                $result = $q->execute($values, Doctrine_Core::HYDRATE_ARRAY);
-                $querySucceeded = true;
-            }
-            catch (Doctrine_Connection_Exception $e) {
-                if(++$num > 10 || strpos($e->getMessage(), 'SQLSTATE[40001]') === false) {
-                    // not a deadlock, or more than 10 tries? rethrow exception
-                    throw $e;
-                }
-            }
-        } while (!$querySucceeded);
+
+        $result = $q->execute($values, Doctrine_Core::HYDRATE_ARRAY);
 
         return isset($result[0]['max_version']) ? $result[0]['max_version']:0;
     }

--- a/lib/Doctrine/AuditLog/Listener.php
+++ b/lib/Doctrine/AuditLog/Listener.php
@@ -62,7 +62,7 @@ class Doctrine_AuditLog_Listener extends Doctrine_Record_Listener
         $name = $version['alias'] === null ? $version['name'] : $version['alias'];
 
         $conn = Doctrine_Manager::getInstance()->getCurrentConnection();
-        $conn->beginTransaction();
+        $conn->getDbh()->prepare('START TRANSACTION')->execute();
 
         $record = $event->getInvoker();
         $record->set($name, $this->_getNextVersion($record));
@@ -86,7 +86,7 @@ class Doctrine_AuditLog_Listener extends Doctrine_Record_Listener
             $version->save();
         }
         $conn = Doctrine_Manager::getInstance()->getCurrentConnection();
-        $conn->commit();
+        $conn->getDbh()->prepare('COMMIT')->execute();
     }
 
     public function postUpdate(Doctrine_Event $event)


### PR DESCRIPTION
Also select the forUpdate on the base table, instead of the version
table. Using the version table will result in more deadlocks (due to
inserts instead of updates).
