### PR TITLE
Only overwrite local changes if current state == proxy

### DIFF
--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1844,7 +1844,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
             if (isset($this->_identityMap[$id])) {
                 $record = $this->_identityMap[$id];
                 if ($record->getTable()->getAttribute(Doctrine_Core::ATTR_HYDRATE_OVERWRITE)) {
-                    $record->hydrate($this->_data);
+                    $record->hydrate($this->_data, $record->state() == Doctrine_Record::STATE_PROXY);
                     if ($record->state() == Doctrine_Record::STATE_PROXY) {
                         if (!$record->isInProxyState()) {
                             $record->state(Doctrine_Record::STATE_CLEAN);


### PR DESCRIPTION
If the current state == proxy, it makes sense to overwrite all data with
the recently fetched values. However, when we are in a other state we
probably fetched a whole record before and maybe did some local
modifications that we don't want to lose.
