### PR TITLE
Make AuditLog behavior play nice with SoftDelete

### DIFF
--- a/lib/Doctrine/AuditLog.php
+++ b/lib/Doctrine/AuditLog.php
@@ -160,8 +160,9 @@ class Doctrine_AuditLog extends Doctrine_Record_Generator
             $conditions[] = $className . '.' . $id . ' = ?';
             $values[] = $record->get($id);
         }
-        if ($this->_options['table']->hasColumn('deleted_at')) {
-            $conditions[] = '(' . $className . '.deleted_at IS NULL OR ' . $className . '.deleted_at IS NOT NULL)';
+        if ($this->_options['table']->hasTemplate('SoftDelete')) {
+            $columnName = $this->_options['table']->getTemplate('SoftDelete')->getOption('name');
+            $conditions[] = '(' . $className . '.' . $columnName . ' IS NULL OR ' . $className . '.' . $columnName . ' IS NOT NULL)';
         }
 
         // Lock the version table using 'FOR UPDATE'

--- a/lib/Doctrine/AuditLog.php
+++ b/lib/Doctrine/AuditLog.php
@@ -160,6 +160,9 @@ class Doctrine_AuditLog extends Doctrine_Record_Generator
             $conditions[] = $className . '.' . $id . ' = ?';
             $values[] = $record->get($id);
         }
+        if ($this->_options['table']->hasColumn('deleted_at')) {
+            $conditions[] = '(' . $className . '.deleted_at IS NULL OR ' . $className . '.deleted_at IS NOT NULL)';
+        }
 
         // Lock the version table using 'FOR UPDATE'
         $q = Doctrine_Core::getTable($className)


### PR DESCRIPTION
If both the behaviors AuditLog and SoftDelete are used on a class, sometimes AuditLog can't determine the new version number (`AuditLog::getMaxVersion` returns `0`). This leads to conflicts on inserting a new version with number `1` in the version table