### PR TITLE
Change return type

### DIFF
--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -992,7 +992,7 @@ abstract class Doctrine_Query_Abstract
      * executes the query and populates the data set
      *
      * @param array $params
-     * @return Doctrine_Collection            the root collection
+     * @return mixed            the root collection
      */
     public function execute($params = array(), $hydrationMode = null)
     {


### PR DESCRIPTION
Depenending on the $hydrationMode this function can return a lot of diffferent things. The old behaviour is breaking PHPStan.