### PR TITLE
Trigger error when starting a transaction while PDO is in transaction

### DIFF
--- a/lib/Doctrine/Transaction.php
+++ b/lib/Doctrine/Transaction.php
@@ -199,21 +199,21 @@ class Doctrine_Transaction extends Doctrine_Connection_Module
             }
 
             $listener->postSavepointCreate($event);
-        } else {
-            if ($this->_nestingLevel == 0) {
-                $event = new Doctrine_Event($this, Doctrine_Event::TX_BEGIN);
+        } elseif ($this->_nestingLevel == 0  && $this->conn->getDbh()->inTransaction()) {
+            trigger_error('There is an active transaction while nestingLevel==0');
+        } elseif ($this->_nestingLevel == 0) {
+            $event = new Doctrine_Event($this, Doctrine_Event::TX_BEGIN);
 
-                $listener->preTransactionBegin($event);
+            $listener->preTransactionBegin($event);
 
-                if ( ! $event->skipOperation) {
-                    try {
-                        $this->_doBeginTransaction();
-                    } catch (Exception $e) {
-                        throw new Doctrine_Transaction_Exception($e->getMessage());
-                    }
+            if ( ! $event->skipOperation) {
+                try {
+                    $this->_doBeginTransaction();
+                } catch (Exception $e) {
+                    throw new Doctrine_Transaction_Exception($e->getMessage());
                 }
-                $listener->postTransactionBegin($event);
             }
+            $listener->postTransactionBegin($event);
         }
 
         $level = ++$this->_nestingLevel;


### PR DESCRIPTION
We've had some errors where PDO would throw a "There is already an active transaction" Exception. This modification does not take away the root cause, but should mitigate the problems