### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "ext-pdo": "*",
         "symfony/yaml": "^5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "recras/doctrine1",
     "type": "library",
-    "description": "PHP5^H7 Database ORM",
+    "description": "PHP Database ORM",
     "keywords": ["orm", "database"],
     "homepage": "http://www.doctrine-project.org",
     "license": "LGPL-2.1-or-later",
@@ -11,7 +11,7 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "require": {
-        "php": ">=7",
+        "php": ">=7.4",
         "ext-pdo": "*",
         "symfony/yaml": "^5.2"
     },

--- a/lib/Doctrine/Access.php
+++ b/lib/Doctrine/Access.php
@@ -143,7 +143,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @see   set, offsetSet, __set
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): mixed
     {
         return $this->remove($offset);
     }

--- a/lib/Doctrine/Access.php
+++ b/lib/Doctrine/Access.php
@@ -110,7 +110,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         // array notation with no index was causing 'undefined variable: $offset' notices in php7,
         // for example:
@@ -143,9 +143,9 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @see   set, offsetSet, __set
      * @param mixed $offset
      */
-    public function offsetUnset($offset): mixed
+    public function offsetUnset($offset): void
     {
-        return $this->remove($offset);
+        $this->remove($offset);
     }
 
     /**

--- a/lib/Doctrine/Access.php
+++ b/lib/Doctrine/Access.php
@@ -98,7 +98,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  boolean Whether or not this object contains $offset
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->contains($offset);
     }
@@ -128,7 +128,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @param   mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ( ! isset($offset)) {
             $this->add($value);

--- a/lib/Doctrine/Adapter/Mock.php
+++ b/lib/Doctrine/Adapter/Mock.php
@@ -233,7 +233,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
      *
      * @return integer $count
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_queries);
     }

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -1084,6 +1084,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @return \ArrayIterator<mixed,\Doctrine_Record>
      * @phpstan-return \ArrayIterator<mixed,T>
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $data = $this->data;

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -34,7 +34,7 @@
  * @phpstan-template T of \Doctrine_Record
  * @phpstan-implements \IteratorAggregate<T>
  */
-class Doctrine_Collection extends Doctrine_Access implements Countable, IteratorAggregate, Serializable
+class Doctrine_Collection extends Doctrine_Access implements Countable, IteratorAggregate
 {
     /**
      * @var \Doctrine_Record[] $data                     an array containing the records of this collection
@@ -169,7 +169,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return string
      */
-    public function serialize()
+    public function __serialize()
     {
         $vars = get_object_vars($this);
 
@@ -191,7 +191,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @param string $serialized
      * @return void
      */
-    public function unserialize($serialized)
+    public function __unserialize($serialized)
     {
         $manager    = Doctrine_Manager::getInstance();
         $connection    = $manager->getCurrentConnection();

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -450,7 +450,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }

--- a/lib/Doctrine/Collection/OnDemand.php
+++ b/lib/Doctrine/Collection/OnDemand.php
@@ -64,7 +64,7 @@ class Doctrine_Collection_OnDemand implements Iterator
         }
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->index = 0;
         $this->_stmt->closeCursor();
@@ -73,24 +73,24 @@ class Doctrine_Collection_OnDemand implements Iterator
         $this->_hydrateCurrent();
     }
 
-    public function key()
+    public function key(): mixed
     {
         return $this->index;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->_current;
     }
 
-    public function next()
+    public function next(): void
     {
         $this->_current = null;
         $this->index++;
         $this->_hydrateCurrent();
     }
 
-    public function valid()
+    public function valid(): bool
     {
         if ( ! is_null($this->_current) && $this->_current !== false) {
             return true;

--- a/lib/Doctrine/Column.php
+++ b/lib/Doctrine/Column.php
@@ -145,7 +145,7 @@ class Doctrine_Column extends Doctrine_Access implements IteratorAggregate, Coun
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_definition);
     }

--- a/lib/Doctrine/Connection.php
+++ b/lib/Doctrine/Connection.php
@@ -1151,7 +1151,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_count;
     }

--- a/lib/Doctrine/Connection.php
+++ b/lib/Doctrine/Connection.php
@@ -1141,6 +1141,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return ArrayIterator<Doctrine_Table>        SPL ArrayIterator object
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->tables);

--- a/lib/Doctrine/Connection.php
+++ b/lib/Doctrine/Connection.php
@@ -53,7 +53,7 @@
  * @author      Konsta Vesterinen <kvesteri@cc.hut.fi>
  * @author      Lukas Smith <smith@pooteeweet.org> (MDB2 library)
  */
-abstract class Doctrine_Connection extends Doctrine_Configurable implements Countable, IteratorAggregate, Serializable
+abstract class Doctrine_Connection extends Doctrine_Configurable implements Countable, IteratorAggregate
 {
     /**
      * @var $dbh                                the database handler
@@ -1544,7 +1544,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return string $serialized
      */
-    public function serialize()
+    public function __serialize()
     {
         $vars = get_object_vars($this);
         $vars['dbh'] = null;
@@ -1557,7 +1557,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @param string $serialized
      */
-    public function unserialize($serialized)
+    public function __unserialize($serialized)
     {
         $array = unserialize($serialized);
 

--- a/lib/Doctrine/Connection/Profiler.php
+++ b/lib/Doctrine/Connection/Profiler.php
@@ -134,6 +134,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->events);

--- a/lib/Doctrine/Connection/Profiler.php
+++ b/lib/Doctrine/Connection/Profiler.php
@@ -144,7 +144,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      * 
      * @return integer
      */
-    public function count() 
+    public function count(): int
     {
         return count($this->events);
     }

--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -311,7 +311,7 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
         $data = $this->_conn->getListener()->preFetch($event);
 
         if ( ! $event->skipOperation) {
-            $data = $this->_stmt->fetch($fetchMode, $cursorOrientation, $cursorOffset);
+            $data = $this->_stmt->fetch($fetchMode, $cursorOrientation, $cursorOffset ?? 0);
         }
 
         $this->_conn->getListener()->postFetch($event);

--- a/lib/Doctrine/Formatter.php
+++ b/lib/Doctrine/Formatter.php
@@ -274,6 +274,6 @@ class Doctrine_Formatter extends Doctrine_Connection_Module
     public function getTableName($table)
     {
         $format = $this->conn->getAttribute(Doctrine_Core::ATTR_TBLNAME_FORMAT);
-        return sprintf($format, str_replace(sprintf($format, null), null, $table));
+        return sprintf($format, str_replace(sprintf($format, null), '', $table));
     }
 }

--- a/lib/Doctrine/Locator.php
+++ b/lib/Doctrine/Locator.php
@@ -176,7 +176,7 @@ class Doctrine_Locator implements Countable, IteratorAggregate
      * @see Countable interface
      * @return integer              the number of resources
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_resources);
     }

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -567,7 +567,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_connections);
     }
@@ -577,6 +577,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_connections);

--- a/lib/Doctrine/Node.php
+++ b/lib/Doctrine/Node.php
@@ -160,7 +160,7 @@ class Doctrine_Node implements IteratorAggregate
      * @param string $type                      type of iterator (Pre | Post | Level)
      * @param array $options                    options
      */
-    public function getIterator($type = null, $options = null)
+    public function getIterator($type = null, $options = null): Traversable
     {
         if ($type === null) {
             $type = (isset($this->iteratorType) ? $this->iteratorType : 'Pre');

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -2197,7 +2197,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      * @param mixed[] $params        an array of prepared statement parameters
      * @return integer             the count of this query
      */
-    public function count($params = array())
+    public function count($params = array()): int
     {
         $q = $this->getCountSqlQuery();
         $params = $this->getCountQueryParams($params);

--- a/lib/Doctrine/RawSql.php
+++ b/lib/Doctrine/RawSql.php
@@ -344,7 +344,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
      * @param array $params        an array of prepared statement parameters
      * @return integer             the count of this query
      */
-    public function count($params = array())
+    public function count($params = array()): int
     {
         $sql = $this->getCountSqlQuery();
         $params = $this->getCountQueryParams($params);

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -2142,6 +2142,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * implements IteratorAggregate interface
      * @return Doctrine_Record_Iterator     iterator through data
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new Doctrine_Record_Iterator($this);

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -31,7 +31,7 @@
  * @since       1.0
  * @version     $Revision: 7673 $
  */
-abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Countable, IteratorAggregate, Serializable
+abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Countable, IteratorAggregate
 {
     /**
      * STATE CONSTANTS
@@ -790,7 +790,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @return string
      */
-    public function serialize()
+    public function __serialize()
     {
         $event = new Doctrine_Event($this, Doctrine_Event::RECORD_SERIALIZE);
 
@@ -847,7 +847,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @param string $serialized                Doctrine_Record as serialized string
      * @throws Doctrine_Record_Exception        if the cleanData operation fails somehow
      */
-    public function unserialize($serialized)
+    public function __unserialize($serialized)
     {
         $event = new Doctrine_Event($this, Doctrine_Event::RECORD_UNSERIALIZE);
         

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -185,7 +185,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @var array
      */
-    protected $_invokedSaveHooks = false;
+    protected $_invokedSaveHooks = [];
 
     /**
      * @var integer $index                  this index is used for creating object identifiers
@@ -1533,8 +1533,8 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         } else if (in_array($type, array('integer', 'int')) && is_numeric($old) && is_numeric($new)) {
             return $old != $new;
         } else if ($type == 'timestamp' || $type == 'date') {
-            $oldStrToTime = strtotime($old);
-            $newStrToTime = strtotime($new);
+            $oldStrToTime = strtotime($old ?? '');
+            $newStrToTime = strtotime($new ?? '');
             if ($oldStrToTime && $newStrToTime) {
                 return $oldStrToTime !== $newStrToTime;
             } else {

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -1850,7 +1850,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @return integer          the number of columns in this record
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_data);
     }

--- a/lib/Doctrine/Record/Iterator.php
+++ b/lib/Doctrine/Record/Iterator.php
@@ -68,7 +68,7 @@ class Doctrine_Record_Iterator extends ArrayIterator
      *
      * @return mixed
      */
-    public function current()
+    public function current(): mixed
     {
         $value = parent::current();
 

--- a/lib/Doctrine/Relation.php
+++ b/lib/Doctrine/Relation.php
@@ -190,7 +190,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         }
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): mixed
     {
         $this->definition[$offset] = false;
     }

--- a/lib/Doctrine/Relation.php
+++ b/lib/Doctrine/Relation.php
@@ -174,7 +174,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         return isset($this->definition[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (isset($this->definition[$offset])) {
             return $this->definition[$offset];
@@ -183,7 +183,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         return null;
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (isset($this->definition[$offset])) {
             $this->definition[$offset] = $value;

--- a/lib/Doctrine/Relation.php
+++ b/lib/Doctrine/Relation.php
@@ -169,7 +169,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         return $this->definition['equal'];
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->definition[$offset]);
     }
@@ -190,7 +190,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         }
     }
 
-    public function offsetUnset($offset): mixed
+    public function offsetUnset($offset): void
     {
         $this->definition[$offset] = false;
     }

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1136,7 +1136,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
         }
 
         if ( ! is_array($orderBy)) {
-            $e1 = explode(',', $orderBy);
+            $e1 = explode(',', $orderBy ?? '');
         } else {
             $e1 = $orderBy;
         }

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1958,7 +1958,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
      *
      * @return integer number of records in the table
      */
-    public function count()
+    public function count(): int
     {
         return $this->createQuery()->count();
     }

--- a/lib/Doctrine/Table/Repository.php
+++ b/lib/Doctrine/Table/Repository.php
@@ -138,6 +138,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * getIterator
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->registry);

--- a/lib/Doctrine/Table/Repository.php
+++ b/lib/Doctrine/Table/Repository.php
@@ -102,7 +102,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * Doctrine_Registry implements interface Countable
      * @return integer                      the number of records this registry has
      */
-    public function count()
+    public function count(): int
     {
         return count($this->registry);
     }

--- a/lib/Doctrine/Validator/ErrorStack.php
+++ b/lib/Doctrine/Validator/ErrorStack.php
@@ -161,7 +161,7 @@ class Doctrine_Validator_ErrorStack extends Doctrine_Access implements Countable
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_errors);
     }

--- a/lib/Doctrine/Validator/Exception.php
+++ b/lib/Doctrine/Validator/Exception.php
@@ -56,7 +56,7 @@ class Doctrine_Validator_Exception extends Doctrine_Exception implements Countab
         return new ArrayIterator($this->invalid);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->invalid);
     }


### PR DESCRIPTION
- Return types
- Serialization improvements
- No passing `null` where internal PHP functions expect a string