### PR TITLE
Build model: end with EOL

### DIFF
--- a/lib/Doctrine/Import/Builder.php
+++ b/lib/Doctrine/Import/Builder.php
@@ -1073,6 +1073,7 @@ PHP;
             $extends .= ' implements \Sentry\Serializer\SerializableInterface';
             $setUpCode .= $this->buildToSentry();
         }
+        $setUpCode .= PHP_EOL;
 
         $docs = PHP_EOL . $this->buildPhpDocs($definition);
 


### PR DESCRIPTION
Our code style includes a newline at the end of files, currently `doctrinebuildtest` fails because the build task does not include this