### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -85,7 +85,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @param Doctrine_Table<T>|class-string<T> $table
      * @param string|null $keyColumn
      */
-    public function __construct($table, $keyColumn = null)
+    public function __construct($table, ?string $keyColumn = null)
     {
         if ( ! ($table instanceof Doctrine_Table)) {
             $table = Doctrine_Core::getTable($table);
@@ -125,7 +125,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @throws Doctrine_Manager_Exception 
      * @throws Doctrine_Connection_Exception 
      */
-    public static function create($table, $keyColumn = null, $class = null)
+    public static function create($table, ?string$keyColumn = null, ?string $class = null)
     {
         if (is_null($class)) {
             if ( ! $table instanceof Doctrine_Table) {
@@ -465,7 +465,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @param string $key                          optional key for the record
      * @return boolean
      */
-    public function add($record, $key = null)
+    public function add($record, ?string $key = null)
     {
         if (isset($this->referenceField)) {
             $value = $this->reference->get($this->relation->getLocalFieldName());
@@ -542,7 +542,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @param string|null $name
      * @return Doctrine_Query|void
      */
-    public function loadRelated($name = null)
+    public function loadRelated(?string $name = null)
     {
         $list = array();
         $query = $this->_table->createQuery();
@@ -923,7 +923,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @param bool $processDiff
      * @return $this
      */
-    public function save(Doctrine_Connection $conn = null, $processDiff = true)
+    public function save(?Doctrine_Connection $conn = null, bool $processDiff = true)
     {
         if ($conn == null) {
             $conn = $this->_table->getConnection();
@@ -959,7 +959,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @param bool $processDiff
      * @return $this
      */
-    public function replace(Doctrine_Connection $conn = null, $processDiff = true)
+    public function replace(?Doctrine_Connection $conn = null, bool $processDiff = true)
     {
         if ($conn == null) {
             $conn = $this->_table->getConnection();
@@ -994,7 +994,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * @param bool $clearColl
      * @return $this
      */
-    public function delete(Doctrine_Connection $conn = null, $clearColl = true)
+    public function delete(?Doctrine_Connection $conn = null, bool $clearColl = true)
     {
         if ($conn == null) {
             $conn = $this->_table->getConnection();

--- a/lib/Doctrine/Locator.php
+++ b/lib/Doctrine/Locator.php
@@ -55,7 +55,7 @@ class Doctrine_Locator implements Countable, IteratorAggregate
      *
      * @param array
      */
-    public function __construct(array $defaults = null)
+    public function __construct(?array $defaults = null)
     {
         if (null !== $defaults) {
             foreach ($defaults as $name => $resource) {

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -2247,7 +2247,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      * @return Doctrine_Query  Copy of the Doctrine_Query instance.
      * @phpstan-return Doctrine_Query<T>
      */
-    public function copy(Doctrine_Query $query = null)
+    public function copy(?Doctrine_Query $query = null)
     {
         if ( ! $query) {
             $query = $this;

--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -281,8 +281,8 @@ abstract class Doctrine_Query_Abstract
      * @param Doctrine_Connection  The connection object the query will use.
      * @param Doctrine_Hydrator_Abstract  The hydrator that will be used for generating result sets.
      */
-    public function __construct(Doctrine_Connection $connection = null,
-            Doctrine_Hydrator_Abstract $hydrator = null)
+    public function __construct(?Doctrine_Connection $connection = null,
+            ?Doctrine_Hydrator_Abstract $hydrator = null)
     {
         if ($connection === null) {
             $connection = Doctrine_Manager::getInstance()->getCurrentConnection();

--- a/lib/Doctrine/Query/Part.php
+++ b/lib/Doctrine/Query/Part.php
@@ -42,7 +42,7 @@ abstract class Doctrine_Query_Part
     /**
      * @param Doctrine_Query $query         the query object associated with this parser
      */
-    public function __construct($query, Doctrine_Query_Tokenizer $tokenizer = null)
+    public function __construct($query, ?Doctrine_Query_Tokenizer $tokenizer = null)
     {
         $this->query = $query;
 

--- a/lib/Doctrine/RawSql.php
+++ b/lib/Doctrine/RawSql.php
@@ -51,7 +51,7 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
      * @param Doctrine_Connection $connection The connection object the query will use.
      * @param Doctrine_Hydrator_Abstract $hydrator The hydrator that will be used for generating result sets.
      */
-    function __construct(Doctrine_Connection $connection = null, Doctrine_Hydrator_Abstract $hydrator = null) {
+    function __construct(?Doctrine_Connection $connection = null, ?Doctrine_Hydrator_Abstract $hydrator = null) {
         parent::__construct($connection, $hydrator);
 
         // Fix #1472. It's alid to disable QueryCache since there's no DQL for RawSql.

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -1766,7 +1766,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @param Doctrine_Connection $conn     optional connection parameter
      * @throws Exception                    if record is not valid and validation is active
      */
-    public function save(Doctrine_Connection $conn = null)
+    public function save(?Doctrine_Connection $conn = null)
     {
         if ($conn === null) {
             $conn = $this->_table->getConnection();
@@ -1783,7 +1783,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @param Doctrine_Connection $conn                 optional connection parameter
      * @return TRUE if the record was saved sucessfully without errors, FALSE otherwise.
      */
-    public function trySave(Doctrine_Connection $conn = null) {
+    public function trySave(?Doctrine_Connection $conn = null) {
         try {
             $this->save($conn);
             return true;
@@ -1809,7 +1809,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @throws Doctrine_Connection_Exception        if something fails at database level
      * @return integer                              number of rows affected
      */
-    public function replace(Doctrine_Connection $conn = null)
+    public function replace(?Doctrine_Connection $conn = null)
     {
         if ($conn === null) {
             $conn = $this->_table->getConnection();
@@ -2210,7 +2210,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @return boolean      true if successful
      */
-    public function delete(Doctrine_Connection $conn = null)
+    public function delete(?Doctrine_Connection $conn = null)
     {
         if ($conn == null) {
             $conn = $this->_table->getConnection();

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -340,7 +340,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @param Doctrine_Event $event  event raised
      * @return Doctrine_Event        the event generated using the type, if not specified
      */
-    public function invokeSaveHooks(string $when, string $type, Doctrine_Event $event = null)
+    public function invokeSaveHooks(string $when, string $type, ? Doctrine_Event $event = null)
     {
         $func = $when . ucfirst($type);
 

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -2043,7 +2043,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
      * @phpstan-param T $record
      * @return Doctrine_Validator_ErrorStack $errorStack
      */
-    public function validateField($fieldName, $value, Doctrine_Record $record = null)
+    public function validateField($fieldName, $value, ?Doctrine_Record $record = null)
     {
         if ($record instanceof Doctrine_Record) {
             $errorStack = $record->getErrorStack();
@@ -2196,7 +2196,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
      * @param string[]|null $fieldNames
      * @return array<int,string> numeric array
      */
-    public function getColumnNames(array $fieldNames = null)
+    public function getColumnNames(?array $fieldNames = null)
     {
         if ($fieldNames === null) {
             return array_keys($this->_columns);

--- a/lib/Doctrine/Tree/Interface.php
+++ b/lib/Doctrine/Tree/Interface.php
@@ -37,7 +37,7 @@ interface Doctrine_Tree_Interface {
      *
      * @param Doctrine_Record $record                    instance of Doctrine_Record
      */
-    public function createRoot(Doctrine_Record $record = null);
+    public function createRoot(?Doctrine_Record $record = null);
 
     /**
      * returns root node

--- a/lib/Doctrine/Tree/NestedSet.php
+++ b/lib/Doctrine/Tree/NestedSet.php
@@ -84,7 +84,7 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
      *
      * @param object $record        instance of Doctrine_Record
      */
-    public function createRoot(Doctrine_Record $record = null)
+    public function createRoot(?Doctrine_Record $record = null)
     {
         if ($this->getAttribute('hasManyRoots')) {
             if ( ! $record || ( ! $record->exists() && ! $record->getNode()->getRootValue())

--- a/tests/DoctrineTest/GroupTest.php
+++ b/tests/DoctrineTest/GroupTest.php
@@ -50,7 +50,7 @@ class GroupTest extends UnitTestCase
         }
         return true;
     }
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run(?DoctrineTest_Reporter $reporter = null, $filter = null)
     {
         set_time_limit(900);
 

--- a/tests/DoctrineTest/UnitTestCase.php
+++ b/tests/DoctrineTest/UnitTestCase.php
@@ -149,7 +149,7 @@ class UnitTestCase
         self::$_passesAndFails['fails'][$class] = $class;
     }
 
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null) 
+    public function run(?DoctrineTest_Reporter $reporter = null, $filter = null)
     {
         foreach (get_class_methods($this) as $method) {
             if (substr($method, 0, 4) === 'test') {

--- a/tests/Ticket/1830TestCase.php
+++ b/tests/Ticket/1830TestCase.php
@@ -13,7 +13,7 @@ class Doctrine_Ticket_1830_TestCase extends Doctrine_UnitTestCase
         $this->prepareData();
     }
 
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run(?DoctrineTest_Reporter $reporter = null, $filter = null)
     {
       parent::run($reporter, $filter);
       $this->manager->closeConnection($this->connection);

--- a/tests/Ticket/1876bTestCase.php
+++ b/tests/Ticket/1876bTestCase.php
@@ -12,7 +12,7 @@ class Doctrine_Ticket_1876b_TestCase extends Doctrine_UnitTestCase
         $this->prepareData();
     }
 
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run(?DoctrineTest_Reporter $reporter = null, $filter = null)
     {
       parent::run($reporter, $filter);
       $this->manager->closeConnection($this->connection);

--- a/tests/Ticket/1935TestCase.php
+++ b/tests/Ticket/1935TestCase.php
@@ -12,7 +12,7 @@ class Doctrine_Ticket_1935_TestCase extends Doctrine_UnitTestCase
         $this->prepareData();
     }
 
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run(?DoctrineTest_Reporter $reporter = null, $filter = null)
     {
         parent::run($reporter, $filter);
         $this->manager->closeConnection($this->connection);

--- a/tests/models/RecordHookTest.php
+++ b/tests/models/RecordHookTest.php
@@ -3,7 +3,7 @@ class RecordHookTest extends Doctrine_Record
 {
     protected $_messages = array();
 
-    public function setTableDefinition()
+    public function setTableDefinition(): void
     {
         $this->hasColumn('name', 'string', null, array('primary' => true));
     }


### PR DESCRIPTION
Implicitly marking parameter as nullable is deprecated in PHP 8.4