### PR TITLE
Fix PHP 8.5 deprecated casts

### DIFF
--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -2623,7 +2623,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
             $localFieldDef  = $rel->getAssociationTable()->getColumnDefinition($localFieldName);
 
             if ($localFieldDef['type'] == 'integer') {
-                $identifier = (integer) $identifier;
+                $identifier = (int) $identifier;
             }
 
             $foreignFieldName = $rel->getForeignFieldName();
@@ -2631,7 +2631,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
 
             if ($foreignFieldDef['type'] == 'integer') {
                 foreach ($ids as $i => $id) {
-                    $ids[$i] = (integer) $id;
+                    $ids[$i] = (int) $id;
                 }
             }
 

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -2347,7 +2347,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable
                 case 'set':
                     return explode(',', $value);
                 case 'boolean':
-                    return (boolean) $value;
+                    return (bool) $value;
                 case 'array':
                 case 'object':
                     if (is_string($value)) {

--- a/lib/Doctrine/Validator/Unsigned.php
+++ b/lib/Doctrine/Validator/Unsigned.php
@@ -50,7 +50,7 @@ class Doctrine_Validator_Unsigned extends Doctrine_Validator_Driver
             return false;
         }
 
-        if ((double) $value >= 0)
+        if ((float) $value >= 0)
         {
             return true;
         }


### PR DESCRIPTION
`(boolean)`, `(double)`, and `(integer)` are deprecated as of PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_non-standard_cast_names